### PR TITLE
feat: profile | auth popup on follow/connect when no user / connection request styling overflow

### DIFF
--- a/src/components/Dashboard/Profile/ConnectionsAndFollows/Connections/ConnectionElements.jsx
+++ b/src/components/Dashboard/Profile/ConnectionsAndFollows/Connections/ConnectionElements.jsx
@@ -24,16 +24,18 @@ export const DotIcon = styled(BsDot)`
 `;
 export const ConnectionButton = styled.button`
     padding: 5px 34px;
-    margin: 15px 4px;
+    margin: 15px 0px;
     border-radius: 50px;
     background: #0e0e0e;
     align-items: center;
-    width: auto;
+    width: 245px;
     color: #e0e0e0;
     border: 1px solid #3a3a3a;
     cursor: pointer;
     transition: all 0.3s ease-in-out;
     font-size: 14px;
+    display: flex;
+    justify-content: center;
 
     &:hover {
         background: #3a3a3a;

--- a/src/components/Dashboard/Profile/ConnectionsAndFollows/Connections/ConnectionElements.jsx
+++ b/src/components/Dashboard/Profile/ConnectionsAndFollows/Connections/ConnectionElements.jsx
@@ -23,8 +23,8 @@ export const DotIcon = styled(BsDot)`
     color: #d9d9d9;
 `;
 export const ConnectionButton = styled.button`
-    padding: 5px 15px;
-    margin: 15px 0;
+    padding: 5px 34px;
+    margin: 15px 4px;
     border-radius: 50px;
     background: #0e0e0e;
     align-items: center;

--- a/src/components/Dashboard/Profile/ConnectionsAndFollows/ConnectionsAndFollows.jsx
+++ b/src/components/Dashboard/Profile/ConnectionsAndFollows/ConnectionsAndFollows.jsx
@@ -183,7 +183,7 @@ const ConnectionsAndFollows = ({ userDetail, setShowAuthPopup }) => {
                                         Cancel Request
                                     </ConnectionButton>
                                 ) : (
-                                    <div style={{ display: "flex", justifyContent: "space-" }}>
+                                    <div style={{ display: "flex"}}>
                                         <ConnectionButton onClick={() => handleRemoveConnectionRequest(followUserId)}>
                                             Reject
                                         </ConnectionButton>

--- a/src/components/Dashboard/Profile/ConnectionsAndFollows/ConnectionsAndFollows.jsx
+++ b/src/components/Dashboard/Profile/ConnectionsAndFollows/ConnectionsAndFollows.jsx
@@ -14,7 +14,7 @@ import { RouterLink } from "../../../Tools/ToolsElements";
 import { CircleSpinner } from "react-spinners-kit";
 import { ConnectionButton } from "./Connections/ConnectionElements";
 
-const ConnectionsAndFollows = ({ userDetail }) => {
+const ConnectionsAndFollows = ({ userDetail, setShowAuthPopup }) => {
     const dispatch = useDispatch();
     const { user } = useSelector((state) => state.auth);
 
@@ -58,6 +58,9 @@ const ConnectionsAndFollows = ({ userDetail }) => {
     }, [followData, followers, user?._id]);
 
     const handleFollow = async () => {
+        if (!user) {
+            return setShowAuthPopup(true);
+        }
         if (!isFollowed && followUserId) {
             await dispatch(followUser(followUserId));
         }
@@ -98,6 +101,9 @@ const ConnectionsAndFollows = ({ userDetail }) => {
 
     const handleSendConnectionRequest = useCallback(
         async (connectionUserId) => {
+            if (!user) {
+                return setShowAuthPopup(true);
+            }
             if (connectionUserId) {
                 await dispatch(sendConnectionRequest(connectionUserId));
             }
@@ -143,15 +149,7 @@ const ConnectionsAndFollows = ({ userDetail }) => {
 
     return (
         <FollowContainer>
-            <div
-                style={{
-                    display: "flex",
-                    justifyContent: "start",
-                    alignItems: "center",
-                    width: "100%",
-                    gap: "10px",
-                }}
-            >
+            <div>
                 {/* follow */}
                 {user && followUserId && user?._id === followUserId ? (
                     <FollowButton>
@@ -185,14 +183,14 @@ const ConnectionsAndFollows = ({ userDetail }) => {
                                         Cancel Request
                                     </ConnectionButton>
                                 ) : (
-                                    <>
+                                    <div style={{ display: "flex" }}>
                                         <ConnectionButton onClick={() => handleRemoveConnectionRequest(followUserId)}>
                                             Reject Request
                                         </ConnectionButton>
                                         <ConnectionButton onClick={() => handleAcceptConnectionRequest(followUserId)}>
                                             Accept Request
                                         </ConnectionButton>
-                                    </>
+                                    </div>
                                 )}
                             </>
                         )

--- a/src/components/Dashboard/Profile/ConnectionsAndFollows/ConnectionsAndFollows.jsx
+++ b/src/components/Dashboard/Profile/ConnectionsAndFollows/ConnectionsAndFollows.jsx
@@ -183,12 +183,12 @@ const ConnectionsAndFollows = ({ userDetail, setShowAuthPopup }) => {
                                         Cancel Request
                                     </ConnectionButton>
                                 ) : (
-                                    <div style={{ display: "flex" }}>
+                                    <div style={{ display: "flex", justifyContent: "space-" }}>
                                         <ConnectionButton onClick={() => handleRemoveConnectionRequest(followUserId)}>
-                                            Reject Request
+                                            Reject
                                         </ConnectionButton>
                                         <ConnectionButton onClick={() => handleAcceptConnectionRequest(followUserId)}>
-                                            Accept Request
+                                            Accept
                                         </ConnectionButton>
                                     </div>
                                 )}
@@ -202,7 +202,10 @@ const ConnectionsAndFollows = ({ userDetail, setShowAuthPopup }) => {
                             <CircleSpinner size={16} isLoading={isLoading} />
                         </ConnectionButton>
                     ) : (
-                        <ConnectionButton onClick={() => handleSendConnectionRequest(followUserId)}>
+                        <ConnectionButton
+                            style={{ width: "245px", margin: "15px 0px" }}
+                            onClick={() => handleSendConnectionRequest(followUserId)}
+                        >
                             Send Request
                         </ConnectionButton>
                     )

--- a/src/components/Dashboard/Profile/ConnectionsAndFollows/ConnectionsAndFollows.jsx
+++ b/src/components/Dashboard/Profile/ConnectionsAndFollows/ConnectionsAndFollows.jsx
@@ -179,15 +179,27 @@ const ConnectionsAndFollows = ({ userDetail, setShowAuthPopup }) => {
                         myConnection.isAccepted === false && (
                             <>
                                 {myConnection.sender === userId ? (
-                                    <ConnectionButton onClick={() => handleRemoveConnectionRequest(followUserId)}>
-                                        Cancel Request
-                                    </ConnectionButton>
-                                ) : (
-                                    <div style={{ display: "flex"}}>
+                                    isConnectionLoading ? (
+                                        <ConnectionButton>
+                                            <CircleSpinner size={16} isLoading={isLoading} />
+                                        </ConnectionButton>
+                                    ) : (
                                         <ConnectionButton onClick={() => handleRemoveConnectionRequest(followUserId)}>
+                                            Cancel Request
+                                        </ConnectionButton>
+                                    )
+                                ) : (
+                                    <div style={{ display: "flex" }}>
+                                        <ConnectionButton
+                                            style={{ width: "auto", margin: "15px 4px" }}
+                                            onClick={() => handleRemoveConnectionRequest(followUserId)}
+                                        >
                                             Reject
                                         </ConnectionButton>
-                                        <ConnectionButton onClick={() => handleAcceptConnectionRequest(followUserId)}>
+                                        <ConnectionButton
+                                            style={{ width: "auto", margin: "15px 4px" }}
+                                            onClick={() => handleAcceptConnectionRequest(followUserId)}
+                                        >
                                             Accept
                                         </ConnectionButton>
                                     </div>
@@ -202,10 +214,7 @@ const ConnectionsAndFollows = ({ userDetail, setShowAuthPopup }) => {
                             <CircleSpinner size={16} isLoading={isLoading} />
                         </ConnectionButton>
                     ) : (
-                        <ConnectionButton
-                            style={{ width: "245px", margin: "15px 0px" }}
-                            onClick={() => handleSendConnectionRequest(followUserId)}
-                        >
+                        <ConnectionButton onClick={() => handleSendConnectionRequest(followUserId)}>
                             Send Request
                         </ConnectionButton>
                     )

--- a/src/components/Dashboard/Profile/ConnectionsAndFollows/Follow/FollowElements.jsx
+++ b/src/components/Dashboard/Profile/ConnectionsAndFollows/Follow/FollowElements.jsx
@@ -11,6 +11,7 @@ export const FollowContainer = styled.div`
 
 export const FollowCount = styled.p`
     font-size: 1rem;
+    margin-top: 10px;
     display: flex;
     padding: 0 10px;
     flex-direction: row;
@@ -28,8 +29,9 @@ export const DotIcon = styled(BsDot)`
     color: #d9d9d9;
 `;
 export const FollowButton = styled.button`
-    padding: 5px 15px;
+    padding: 5px 45px;
     margin: 15px 0;
+    width: stretch;
     border-radius: 50px;
     background: #0e0e0e;
     color: #e0e0e0;

--- a/src/components/Dashboard/Profile/ConnectionsAndFollows/Follow/FollowElements.jsx
+++ b/src/components/Dashboard/Profile/ConnectionsAndFollows/Follow/FollowElements.jsx
@@ -37,6 +37,8 @@ export const FollowButton = styled.button`
     color: #e0e0e0;
     border: 1px solid #3a3a3a;
     cursor: pointer;
+    display: flex;
+    justify-content: center;
     transition: all 0.3s ease-in-out;
 
     &:hover {

--- a/src/components/Dashboard/Profile/UserLinks/UserLinks.jsx
+++ b/src/components/Dashboard/Profile/UserLinks/UserLinks.jsx
@@ -7,7 +7,7 @@ import { CgWebsite } from "react-icons/cg";
 import { cdnContentImagesUrl } from "../../../../features/apiUrl";
 import ConnectionsAndFollows from "../ConnectionsAndFollows/ConnectionsAndFollows";
 
-const UserLinks = ({ userDetail, userDetails }) => {
+const UserLinks = ({ userDetail, userDetails, setShowAuthPopup }) => {
     const socialUsernames = userDetail?.socialLinks?.map(
         (item) => item?.profileUsername !== "" && item?.profileUsername,
     );
@@ -24,7 +24,13 @@ const UserLinks = ({ userDetail, userDetails }) => {
                 <span className={"username"}>@{userDetail?.username}</span>
             </UserInfo>
 
-            {userDetail?.user && <ConnectionsAndFollows userDetail={userDetail} userDetails={userDetails} />}
+            {userDetail?.user && (
+                <ConnectionsAndFollows
+                    userDetail={userDetail}
+                    userDetails={userDetails}
+                    setShowAuthPopup={setShowAuthPopup}
+                />
+            )}
 
             {userDetail?.bio?.length === 0 || !userDetail?.bio ? null : (
                 <UserBio>

--- a/src/components/Dashboard/Profile/UserProfile.jsx
+++ b/src/components/Dashboard/Profile/UserProfile.jsx
@@ -18,6 +18,7 @@ import UserPoints from "./UserPoints/UserPoints";
 import MyCtfCertificates from "./MyCtfCertificates";
 import UnderMaintenance from "../../Other/UnderMaintenance/UnderMaintenance";
 import apiStatus from "../../../features/apiStatus";
+import AuthPopup from "../../../pages/AuthPopup/AuthPopup";
 
 const UserProfile = () => {
     const { isApiLoading, isApiWorking } = apiStatus();
@@ -29,7 +30,7 @@ const UserProfile = () => {
     const { username } = useParams();
 
     const [userDetail, setUserDetail] = useState({});
-
+    const [showAuthPopup, setShowAuthPopup] = useState(false);
     useEffect(() => {
         if (isError) {
             console.log(message);
@@ -76,10 +77,17 @@ const UserProfile = () => {
     const { aboutMe, skills, achievements, projects } = userDetail || {};
     return (
         <Wrapper>
+            {showAuthPopup && (
+                <AuthPopup
+                    onClose={() => {
+                        setShowAuthPopup(false);
+                    }}
+                />
+            )}
             <ProfileContainer>
                 <ProfileHeader userDetail={userDetail} />
                 <ProfileDetailsSection>
-                    <UserLinks userDetail={userDetail} userDetails={userDetails} />
+                    <UserLinks userDetail={userDetail} userDetails={userDetails} setShowAuthPopup={setShowAuthPopup} />
                     <UserDetailsContainer>
                         <UserPoints userDetail={userDetail} allUserDetail={userDetails} blogs={blogs} />
                         {(aboutMe && aboutMe?.length === 0) || aboutMe === undefined ? null : (


### PR DESCRIPTION

fixes issue #603 


## Changes proposed

- fixed the connection request overflow  

- add auth popup when clicking follow or connect and no user is logged in : 



## Screenshots

![image](https://github.com/thecyberworld/TheCyberHUB/assets/75536712/f81d0568-79c4-4bdc-8d30-098a79d350c2)

![image](https://github.com/thecyberworld/TheCyberHUB/assets/75536712/211c04f9-9fe6-466e-a96e-9503e2595cdc)


## Note to reviewers

although in this issue it was asked to show a login popup for non logged in users who click on follow , i added the same functionality for the connect button .



## Code of Conduct

- [ x] By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/thecyberworld/Support/blob/main/CODE_OF_CONDUCT.md) 🖖

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x ] My code follows the code style of this project.
- [x ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
- [x ] This PR does not contain plagiarized content.
- [x ] The title of my pull request is a short description of the requested changes.

---

You can also join our [Discord](https://discord.gg/QHBPq6xP5p) community.
Feel free to check out other cool repositories of the [Thecyberworld](https://github.com/thecyberworld).
Join the Thecyberworld GitHub Organisation by raising an [issue](https://github.com/thecyberworld/Support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.yml&title=Please+invite+me+to+the+GitHub+Community+Organization) (you will be sent an invitation).
