### PR TITLE
fix: to dynamic import

### DIFF
--- a/src/components/Dashboard/Analytics/AnalyticsBarChart.jsx
+++ b/src/components/Dashboard/Analytics/AnalyticsBarChart.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Bar } from "react-chartjs-2";
 import { BarChartContainer } from "./AnalyticsBarChartElements";
-import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from "chart.js";
 import { displayMonths, allOptions as newOptions, allDatasets as newDatasets } from "./AnalyticsUtils";
 import { useAnalyticsChartCustomHook } from "./useAnalyticsChartCustomHook";
+const { Chart: ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } = await import("chart.js");
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
 export function AnalyticsBarChart() {

--- a/src/components/Dashboard/Analytics/AnalyticsDoughnutChart.jsx
+++ b/src/components/Dashboard/Analytics/AnalyticsDoughnutChart.jsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 import { Pie } from "react-chartjs-2";
 import { DoughnutChartContainer } from "./AnalyticsDoughnutChartElements";
 import { displayMonths, allOptions as newOptions, allDatasets as newDatasets } from "./AnalyticsUtils";
 import { useAnalyticsChartCustomHook } from "./useAnalyticsChartCustomHook";
 
+const { Chart: ChartJS, ArcElement, Tooltip, Legend } = await import("chart.js");
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 export function AnalyticsDoughnutChart() {

--- a/src/components/Dashboard/Analytics/AnalyticsMainBarChart.jsx
+++ b/src/components/Dashboard/Analytics/AnalyticsMainBarChart.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Bar } from "react-chartjs-2";
 import { BarChartContainer } from "./AnalyticsMainBarChartElements";
-import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from "chart.js";
 import { displayMonths, allOptions as newOptions, allDatasets as newDatasets } from "./AnalyticsUtils";
 import { useAnalyticsChartCustomHook } from "./useAnalyticsChartCustomHook";
+
+const { Chart: ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } = await import("chart.js");
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 


### PR DESCRIPTION
why: Because Chart.js is an ESM library, in CommonJS modules you should use a dynamic import

<!-- If your PR fixes an open issue, use `Closes #23` to link your PR with the issue. #23 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->
<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

<!-- --------------- -->
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
Correct ways to mark a box:
[x] - Correct; marked as done
[X] - Correct; marked as done

Incorrect ways to mark a box:
[ ] - Incorrect; marked as not done
[x ] - Incorrect;
[ x ] - Incorrect;
[ x] - Incorrect;
-->

## Code of Conduct

- [ ] By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/thecyberworld/Support/blob/main/CODE_OF_CONDUCT.md) 🖖

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

---

You can also join our [Discord](https://discord.gg/QHBPq6xP5p) community.
Feel free to check out other cool repositories of the [Thecyberworld](https://github.com/thecyberworld).
Join the Thecyberworld GitHub Organisation by raising an [issue](https://github.com/thecyberworld/Support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.yml&title=Please+invite+me+to+the+GitHub+Community+Organization) (you will be sent an invitation).
