### PR TITLE
Add copy button to encoded + decoded fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "thecyberhub.org",
             "version": "0.53.14",
             "dependencies": {
-               "@fortawesome/free-solid-svg-icons": "^6.5.2",
+                "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@fortawesome/react-fontawesome": "^0.2.1",
                 "@radix-ui/react-slot": "^1.0.2",
                 "@reduxjs/toolkit": "^2.2.4",
@@ -609,52 +609,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@fortawesome/fontawesome-common-types": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
-            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
-            "hasInstallScript": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@fortawesome/fontawesome-svg-core": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
-            "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
-            "hasInstallScript": true,
-            "peer": true,
-            "dependencies": {
-                "@fortawesome/fontawesome-common-types": "6.5.2"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@fortawesome/free-solid-svg-icons": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
-            "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@fortawesome/fontawesome-common-types": "6.5.2"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@fortawesome/react-fontawesome": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.1.tgz",
-            "integrity": "sha512-ldr5QO2MneAX5W5WBCYB2pZp/PiHDD1hy9YEBLcXUyJb0qnO86oP8RU+CgmYVSH/R4Dbe2ernhcWOrcgaKD9NQ==",
-            "dependencies": {
-                "prop-types": "^15.8.1"
-            },
-            "peerDependencies": {
-                "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-                "react": ">=16.3"
-            }
-        },
         "node_modules/@esbuild/android-x64": {
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
@@ -1044,6 +998,52 @@
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
+            "hasInstallScript": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-svg-core": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
+            "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
+            "hasInstallScript": true,
+            "peer": true,
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.5.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
+            "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.5.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/react-fontawesome": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.1.tgz",
+            "integrity": "sha512-ldr5QO2MneAX5W5WBCYB2pZp/PiHDD1hy9YEBLcXUyJb0qnO86oP8RU+CgmYVSH/R4Dbe2ernhcWOrcgaKD9NQ==",
+            "dependencies": {
+                "prop-types": "^15.8.1"
+            },
+            "peerDependencies": {
+                "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+                "react": ">=16.3"
             }
         },
         "node_modules/@humanwhocodes/config-array": {

--- a/src/components/Tools/EncoderDecoder.jsx/EncoderCode.jsx
+++ b/src/components/Tools/EncoderDecoder.jsx/EncoderCode.jsx
@@ -1,16 +1,5 @@
 import React from "react";
-import styled from "styled-components";
-import { toast } from "react-toastify";
 import { CodeContainer } from "./EncoderCodeElement";
-
-const CopyButton = styled.button`
-    padding: 5px 10px;
-    background-color: #ff6b08;
-    color: white;
-    border: none;
-    border-radius: 3px;
-    cursor: pointer;
-`;
 
 function EncoderCode(props) {
     function Base64() {
@@ -60,43 +49,13 @@ function EncoderCode(props) {
         });
     }
 
-    function copyToClipboard(text) {
-        navigator.clipboard.writeText(text).then(() => {
-            toast.success("Copied to clipboard!");
-        });
-    }
-
     return (
         <div>
-            <h1>Base64 Encode</h1>
-            <CodeContainer>
-                <p>{Base64()}</p>
-                <CopyButton onClick={() => copyToClipboard(Base64())}>Copy</CopyButton>
-            </CodeContainer>
-
-            <h1>Url Encode</h1>
-            <CodeContainer>
-                <p>{Url()}</p>
-                <CopyButton onClick={() => copyToClipboard(Url())}>Copy</CopyButton>
-            </CodeContainer>
-
-            <h1>Full Url Encode</h1>
-            <CodeContainer>
-                <p>{fullURLEncode(props.Input)}</p>
-                <CopyButton onClick={() => copyToClipboard(fullURLEncode(props.Input))}>Copy</CopyButton>
-            </CodeContainer>
-
-            <h1>ASCII HEX Encode</h1>
-            <CodeContainer>
-                <p>{asciiHexEncode(props.Input)}</p>
-                <CopyButton onClick={() => copyToClipboard(asciiHexEncode(props.Input))}>Copy</CopyButton>
-            </CodeContainer>
-
-            <h1>HTML Encode</h1>
-            <CodeContainer>
-                <p>{htmlEncode(props.Input)}</p>
-                <CopyButton onClick={() => copyToClipboard(htmlEncode(props.Input))}>Copy</CopyButton>
-            </CodeContainer>
+            <CodeContainer text={Base64()} title={"Base64 Encode"} />
+            <CodeContainer text={Url()} title={"Url Encode"} />
+            <CodeContainer text={fullURLEncode(props.Input)} title={"Full Url Encode"} />
+            <CodeContainer text={asciiHexEncode(props.Input)} title={"ASCII HEX Encode"} />
+            <CodeContainer text={htmlEncode(props.Input)} title={"HTML Encode"} />
         </div>
     );
 }

--- a/src/components/Tools/EncoderDecoder.jsx/EncoderCode.jsx
+++ b/src/components/Tools/EncoderDecoder.jsx/EncoderCode.jsx
@@ -1,13 +1,26 @@
-import { CodeContainer } from "./EncoderCodeElement";
 import React from "react";
+import styled from "styled-components";
+import { toast } from "react-toastify";
+import { CodeContainer } from "./EncoderCodeElement";
+
+const CopyButton = styled.button`
+    padding: 5px 10px;
+    background-color: #ff6b08;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+`;
 
 function EncoderCode(props) {
     function Base64() {
         return btoa(props.Input);
     }
+
     function Url() {
         return encodeURIComponent(props.Input);
     }
+
     function fullURLEncode(url) {
         let encodedURL = encodeURI(url);
         const urlComponents = encodedURL.split("?");
@@ -28,6 +41,7 @@ function EncoderCode(props) {
 
         return encodedURL;
     }
+
     function asciiHexEncode(inputString) {
         let hexEncoded = "";
 
@@ -39,26 +53,52 @@ function EncoderCode(props) {
 
         return hexEncoded;
     }
+
     function htmlEncode(inputString) {
         return inputString.replace(/[\u00A0-\u9999<>]/gim, function (i) {
             return "&#" + i.charCodeAt(0) + ";";
         });
     }
+
+    function copyToClipboard(text) {
+        navigator.clipboard.writeText(text).then(() => {
+            toast.success("Copied to clipboard!");
+        });
+    }
+
     return (
         <div>
             <h1>Base64 Encode</h1>
             <CodeContainer>
                 <p>{Base64()}</p>
+                <CopyButton onClick={() => copyToClipboard(Base64())}>Copy</CopyButton>
             </CodeContainer>
+
             <h1>Url Encode</h1>
-            <CodeContainer>{Url()}</CodeContainer>
+            <CodeContainer>
+                <p>{Url()}</p>
+                <CopyButton onClick={() => copyToClipboard(Url())}>Copy</CopyButton>
+            </CodeContainer>
+
             <h1>Full Url Encode</h1>
-            <CodeContainer>{fullURLEncode(props.Input)}</CodeContainer>
+            <CodeContainer>
+                <p>{fullURLEncode(props.Input)}</p>
+                <CopyButton onClick={() => copyToClipboard(fullURLEncode(props.Input))}>Copy</CopyButton>
+            </CodeContainer>
+
             <h1>ASCII HEX Encode</h1>
-            <CodeContainer>{asciiHexEncode(props.Input)}</CodeContainer>
+            <CodeContainer>
+                <p>{asciiHexEncode(props.Input)}</p>
+                <CopyButton onClick={() => copyToClipboard(asciiHexEncode(props.Input))}>Copy</CopyButton>
+            </CodeContainer>
+
             <h1>HTML Encode</h1>
-            <CodeContainer>{htmlEncode(props.Input)}</CodeContainer>
+            <CodeContainer>
+                <p>{htmlEncode(props.Input)}</p>
+                <CopyButton onClick={() => copyToClipboard(htmlEncode(props.Input))}>Copy</CopyButton>
+            </CodeContainer>
         </div>
     );
 }
+
 export default EncoderCode;

--- a/src/components/Tools/EncoderDecoder.jsx/EncoderCodeElement.jsx
+++ b/src/components/Tools/EncoderDecoder.jsx/EncoderCodeElement.jsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
+import React from "react";
+import { toast } from "react-toastify";
 
-export const CodeContainer = styled.div`
+export const Container = styled.div`
     height: 50px;
     background: #131313;
     margin-bottom: 10px;
@@ -13,3 +15,30 @@ export const CodeContainer = styled.div`
     overflow: clip;
     color: white;
 `;
+
+const CopyButton = styled.button`
+    padding: 5px 10px;
+    background-color: #ff6b08;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+`;
+
+export const CodeContainer = ({ text, title }) => {
+    function copyToClipboard(text) {
+        navigator.clipboard.writeText(text).then(() => {
+            toast.success("Copied to clipboard!");
+        });
+    }
+
+    return (
+        <>
+            <h1>{title}</h1>
+            <Container>
+                <p>{text}</p>
+                <CopyButton onClick={() => copyToClipboard(text)}>Copy</CopyButton>
+            </Container>
+        </>
+    );
+};

--- a/src/components/Tools/EncoderDecoder.jsx/EncoderCodeElement.jsx
+++ b/src/components/Tools/EncoderDecoder.jsx/EncoderCodeElement.jsx
@@ -6,8 +6,10 @@ export const CodeContainer = styled.div`
     margin-bottom: 10px;
     border-radius: 5px;
     display: flex;
-    flex-direction: column;
-    justify-content: center;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
     padding: 5px;
     overflow: clip;
+    color: white;
 `;


### PR DESCRIPTION
Fixed #818;

Now we have a button to copy the encoded and decoded texts : 



https://github.com/thecyberworld/TheCyberHUB/assets/34707669/438a2608-4956-4be5-a867-a55b095e45b6

Please notice that I pushed the package lock because the dependencies of font awesome was needed but was missing from the file. 
