### PR TITLE
fixed/#869 hide three dots and modal will show

### DIFF
--- a/src/components/AIChat/AIChat.jsx
+++ b/src/components/AIChat/AIChat.jsx
@@ -141,6 +141,15 @@ const AiChat = () => {
         }
     };
 
+    const handleIsUserExit = () => {
+        if (!user) {
+            setIsLoading(true);
+            setShowAuthPopup(true);
+            setIsLoading(false);
+            
+        }
+    };
+
     const getMessages = async () => {
         try {
             const response = await axios.get(`${API_BASE_URL}/get`, {
@@ -300,10 +309,10 @@ const AiChat = () => {
                                 {toggle ? <FaAngleRight /> : <FaAngleLeft />}
                             </ToggleSection>
                             <ChatTitle>{"New Chat"}</ChatTitle>
-                            <SlOptionsVertical />
+                            <SlOptionsVertical className="hidden" />
                         </ChatHeader>
 
-                        <ChatInput onSubmit={handleSendMessage}>
+                        <ChatInput onClick={handleIsUserExit} className="cursor-pointer" onSubmit={handleSendMessage}>
                             <p>Start a New Chat</p>
                             <RecentChatsHeader>
                                 <div className="new-chat-button" onClick={handleNewChat}>


### PR DESCRIPTION
fixed #869 in which the three dots are now hidden and if the user is not loggedin and want to start a new chat , a login modal will open

## Fixes Issue

Three dots hidden until any functionality is not implemented
If the User is not loggedin and want to start a new chat , then  a login modal will appear , it will ask him to login



## Screenshots


https://github.com/thecyberworld/TheCyberHUB/assets/119475896/efe9270e-706c-453f-84f4-77bb4ab8b810



## Note to reviewers
I have closed the previous pr and make a new one as you said me last time to show a modal if user is not loggedin.
Happy Coding

## Code of Conduct

-   [Yes ] By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/thecyberworld/TheCyberHUB/blob/dev/CODE_OF_CONDUCT.md) 🖖

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

-   [Yes] My code follows the code style of this project.
-   [No] My change requires changes to the documentation.
-   [ No] I have updated the documentation accordingly.
-   [ Yes] All new and existing tests passed.
-   [No] This PR does not contain plagiarized content.
-   [Yes] The title of my pull request is a short description of the requested changes.
