### PR TITLE
[FIX] Fixed Search/Sidebar width not full in small screen

### DIFF
--- a/src/components/Common/SocialSidebar/SidebarElements.jsx
+++ b/src/components/Common/SocialSidebar/SidebarElements.jsx
@@ -8,7 +8,6 @@ export const SidebarContainer = styled.div`
     gap: 10px;
     top: 100px;
     width: 100%;
-    max-width: 200px;
     min-width: ${(props) => (props.$sidebarType === "explore" ? "310px" : "400px")};
     color: #fff;
     box-shadow: 0 4px 8px rgb(0 0 0 / 10%);

--- a/src/components/Explore/ExploreElements.jsx
+++ b/src/components/Explore/ExploreElements.jsx
@@ -35,6 +35,8 @@ export const LeftContainer = styled.div`
     flex-direction: column;
     gap: 25px;
     max-width: 300px;
+    width: 100%;
+    align-items: center;
 
     @media screen and (width <= 800px) {
         max-width: 100%;
@@ -50,7 +52,6 @@ export const RightContainer = styled.div`
 
 export const ExploreContentContainer = styled.div`
     background: #090909;
-    display: grid;
     grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
     grid-auto-rows: 1fr;
     grid-gap: 25px;
@@ -59,6 +60,8 @@ export const ExploreContentContainer = styled.div`
     font-size: 0.8rem;
     padding: 15px;
     gap: 15px;
+    display: inline-flex;
+    flex-direction: column;
 `;
 
 export const SearchTypeContainer = styled.div`
@@ -91,7 +94,7 @@ export const SearchTypeButton = styled.button`
 `;
 
 export const BlogsContainer = styled(ExploreContentContainer)`
-    /* ExploreContentContainer */
+    /* BlogsContainer */
 `;
 
 export const JobsContainer = styled(ExploreContentContainer)`


### PR DESCRIPTION
This PR fixes Search/Sidebar width not full in small screen

Closes #802


- Adjusted CSS in `LeftContainer` styled component to resolve responsiveness issues on smaller screen sizes in the Explore.jsx SideBarElements.jsx and ExploreElements.jsx page.

- Changed width properties and align properties for ExploreElements.jsx

![fix](https://github.com/thecyberworld/TheCyberHUB/assets/112303894/18bc35e7-a024-4128-b48e-d88551347f9d)

## Note to reviewers
Please review the changes made in SideBarElements.jsx and ExploreElements.jsx  to ensure that responsiveness is improved across different devices.
-   [x] By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/thecyberworld/TheCyberHUB/blob/dev/CODE_OF_CONDUCT.md) 🖖

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

-   [x] My code follows the code style of this project.
-   [x] My change requires changes to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] All new and existing tests passed.
-   [x] This PR does not contain plagiarized content.
-   [x] The title of my pull request is a short description of the requested changes.

---

